### PR TITLE
feat: use css vars with fallbacks

### DIFF
--- a/src/component.tsx
+++ b/src/component.tsx
@@ -5,9 +5,9 @@ import { fullWidthClassName, zeroRightClassName, noScrollbarsClassName, removedB
 import { GapMode, GapOffset, getGapWidth } from './utils';
 
 export interface BodyScroll {
-  noRelative?: boolean;
-  noImportant?: boolean;
-  gapMode?: GapMode;
+    noRelative?: boolean;
+    noImportant?: boolean;
+    gapMode?: GapMode;
 }
 
 const Style = styleSingleton();
@@ -16,10 +16,10 @@ const Style = styleSingleton();
 // we could not repeat this operation
 // thus we are using style-singleton - only the first "yet correct" style will be applied.
 const getStyles = (
-  { left, top, right, gap }: GapOffset,
-  allowRelative: boolean,
-  gapMode: GapMode = 'margin',
-  important: string
+    { left, top, right, gap }: GapOffset,
+    allowRelative: boolean,
+    gapMode: GapMode = 'margin',
+    important: string
 ) => `
   .${noScrollbarsClassName} {
    overflow: hidden ${important};
@@ -29,28 +29,35 @@ const getStyles = (
     overflow: hidden ${important};
     overscroll-behavior: contain;
     ${[
-      allowRelative && `position: relative ${important};`,
-      gapMode === 'margin' &&
-        `
+    allowRelative && `position: relative ${important};`,
+    gapMode === 'margin' &&
+    `
     padding-left: ${left}px;
     padding-top: ${top}px;
     padding-right: ${right}px;
-    margin-left:0;
-    margin-top:0;
+    margin-left: 0;
+    margin-top: 0;
     margin-right: ${gap}px ${important};
+    margin-right: var(${removedBarSizeVariable}, 0) ${important};
     `,
-      gapMode === 'padding' && `padding-right: ${gap}px ${important};`,
-    ]
-      .filter(Boolean)
-      .join('')}
+    gapMode === 'padding' && (
+        `
+        padding-right: ${gap}px ${important};
+        padding-right: var(${removedBarSizeVariable}, 0) ${important};`
+    ),
+]
+    .filter(Boolean)
+    .join('')}
   }
   
   .${zeroRightClassName} {
     right: ${gap}px ${important};
+    right: var(${removedBarSizeVariable}, 0) ${important};
   }
   
   .${fullWidthClassName} {
     margin-right: ${gap}px ${important};
+    margin-right: var(${removedBarSizeVariable}, 0) ${important};
   }
   
   .${zeroRightClassName} .${zeroRightClassName} {
@@ -70,13 +77,13 @@ const getStyles = (
  * Removes page scrollbar and blocks page scroll when mounted
  */
 export const RemoveScrollBar: React.FC<BodyScroll> = (props) => {
-  const [gap, setGap] = React.useState(getGapWidth(props.gapMode));
+    const [gap, setGap] = React.useState(getGapWidth(props.gapMode));
 
-  React.useEffect(() => {
-    setGap(getGapWidth(props.gapMode));
-  }, [props.gapMode]);
+    React.useEffect(() => {
+        setGap(getGapWidth(props.gapMode));
+    }, [props.gapMode]);
 
-  const { noRelative, noImportant, gapMode = 'margin' } = props;
+    const { noRelative, noImportant, gapMode = 'margin' } = props;
 
-  return <Style styles={getStyles(gap, !noRelative, gapMode, !noImportant ? '!important' : '')} />;
+    return <Style styles={getStyles(gap, !noRelative, gapMode, !noImportant ? '!important' : '')} />;
 };


### PR DESCRIPTION
# What this will do
This will allow `react-remove-scroll-bar` use the CSS variable ` --removed-body-scroll-bar-size` set on the body element.

# Why make this change
When using other modules that depend on this module, I've found that there's no easy way to override the properties added to the body styles.

I'm using `react-focus-on` and want to override the values applied to the body. Currently I get this:

```css
body {
    --removed-body-scroll-bar-size: 15px;
}

body {
    overflow: hidden !important;
    overscroll-behavior: contain;
    position: relative !important;
    padding-left: 0px;
    padding-top: 0px;
    padding-right: 15px;
    margin-left: 0;
    margin-top: 0;
    margin-right: 15px !important;
}
```

The variable `--removed-body-scroll-bar-size` is unused.

Rather than having to add CSS overrides in our main stylesheet to modify the `margin-right` and `padding-right`, I'd like to be able to override just the CSS variable.

The changes in this MR will change the above to this:

```css
body {
    --removed-body-scroll-bar-size: 15px;
}

body {
    overflow: hidden !important;
    overscroll-behavior: contain;
    position: relative !important;
    padding-left: 0px;
    padding-top: 0px;
    padding-right: 15px; /* for browsers that don't support var() */
    padding-right: var(--removed-body-scroll-bar-size, 0); /* if the variable is null it will default to 0 */
    margin-left: 0;
    margin-top: 0;
    margin-right: 15px !important;
    margin-right: var(--removed-body-scroll-bar-size, 0) !important;
}
```

## Note
Prettier has formatted this file too

@theKashey Would you mind having a look please?