### PR TITLE
Fix: Incorrect margin application

### DIFF
--- a/src/component.tsx
+++ b/src/component.tsx
@@ -70,13 +70,8 @@ const getStyles = (
  * Removes page scrollbar and blocks page scroll when mounted
  */
 export const RemoveScrollBar: React.FC<BodyScroll> = (props) => {
-  const [gap, setGap] = React.useState(getGapWidth(props.gapMode));
-
-  React.useEffect(() => {
-    setGap(getGapWidth(props.gapMode));
-  }, [props.gapMode]);
-
   const { noRelative, noImportant, gapMode = 'margin' } = props;
+  const gap = React.useMemo(() => getGapWidth(gapMode), [gapMode]);
 
   return <Style styles={getStyles(gap, !noRelative, gapMode, !noImportant ? '!important' : '')} />;
 };


### PR DESCRIPTION
Related https://github.com/theKashey/react-remove-scroll-bar/issues/31#issuecomment-1124852411

We noticed this issue in [Radix](https://github.com/radix-ui/primitives) since the dependencies in our lock files were changed. I'm pretty sure the underlying issue was exposed when the `style` dependency was [added in this effect](https://github.com/theKashey/react-style-singleton/commit/581f5226d6473049ff5506a9241fa82c18431fca#diff-3f0d30441d44c825e178251d199e3ad61e2730d7a4d0ccbf882f8197bce87767R15) via `react-style-singleton`.

Accurate dependencies makes sense, but I think it was previously masking larger issues in consuming packages. As you can see in the original code, the offset query happens twice, once in the initial state setter and then again inside the `useEffect`. This wasn't an issue before as `style-singleton` wasn't updating the stored style so `offset` would always be calculated from the same initial state.

Here i've switched to updating the `gap` only once (and also when the prop is changed)

I'm not convinced this is the best approach but I've struggled to validate what the correct behaviour should be, or where an appropriate change should be made.

Feel free to point me in the right direction and i'll be happy to update accordingly or work with you to provide a better solution.

Many thanks in advance.

 