### PR TITLE
fix: remove measure time error reporting, fixes #35

### DIFF
--- a/src/component.tsx
+++ b/src/component.tsx
@@ -71,6 +71,11 @@ const getStyles = (
  */
 export const RemoveScrollBar: React.FC<BodyScroll> = (props) => {
   const { noRelative, noImportant, gapMode = 'margin' } = props;
+  /*
+   gap will be measured on every component mount
+   however it will be used only by the "first" invocation
+   due to singleton nature of <Style
+   */
   const gap = React.useMemo(() => getGapWidth(gapMode), [gapMode]);
 
   return <Style styles={getStyles(gap, !noRelative, gapMode, !noImportant ? '!important' : '')} />;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,14 +19,6 @@ const parse = (x: string | null) => parseInt(x || '', 10) || 0;
 const getOffset = (gapMode: GapMode): number[] => {
   const cs = window.getComputedStyle(document.body);
 
-  if (process.env.NODE_ENV !== 'production') {
-    if (cs.overflowY === 'hidden') {
-      console.error(
-        'react-remove-scroll-bar: cannot calculate scrollbar size because it is removed (overflow:hidden on body'
-      );
-    }
-  }
-
   const left = cs[gapMode === 'padding' ? 'paddingLeft' : 'marginLeft'];
   const top = cs[gapMode === 'padding' ? 'paddingTop' : 'marginTop'];
   const right = cs[gapMode === 'padding' ? 'paddingRight' : 'marginRight'];


### PR DESCRIPTION
Totally removes "cannot measure" notification as _explains_ why such a condition cannot be used 